### PR TITLE
Fix code to support 64-bit

### DIFF
--- a/Visual Studio Project Template C#/PluginInfrastructure/IScintillaGateway.cs
+++ b/Visual Studio Project Template C#/PluginInfrastructure/IScintillaGateway.cs
@@ -878,14 +878,14 @@ namespace Kbg.NppPluginNET.PluginInfrastructure
         int GetTextLength();
 
         /// <summary>Retrieve a pointer to a function that processes messages for this Scintilla. (Scintilla feature 2184)</summary>
-        int GetDirectFunction();
+        IntPtr GetDirectFunction();
 
         /// <summary>
         /// Retrieve a pointer value to use as the first argument when calling
         /// the function returned by GetDirectFunction.
         /// (Scintilla feature 2185)
         /// </summary>
-        int GetDirectPointer();
+        IntPtr GetDirectPointer();
 
         /// <summary>Set to overtype (true) or insert mode. (Scintilla feature 2186)</summary>
         void SetOvertype(bool overtype);
@@ -1503,10 +1503,10 @@ namespace Kbg.NppPluginNET.PluginInfrastructure
         void SetViewEOL(bool visible);
 
         /// <summary>Retrieve a pointer to the document object. (Scintilla feature 2357)</summary>
-        int GetDocPointer();
+        IntPtr GetDocPointer();
 
         /// <summary>Change the document object used. (Scintilla feature 2358)</summary>
-        void SetDocPointer(int pointer);
+        void SetDocPointer(IntPtr pointer);
 
         /// <summary>Set which document modification events are sent to the container. (Scintilla feature 2359)</summary>
         void SetModEventMask(int mask);
@@ -1985,7 +1985,7 @@ namespace Kbg.NppPluginNET.PluginInfrastructure
         /// characters in the document.
         /// (Scintilla feature 2520)
         /// </summary>
-        int GetCharacterPointer();
+        IntPtr GetCharacterPointer();
 
         /// <summary>
         /// Return a read-only pointer to a range of characters in the document.
@@ -1993,7 +1993,7 @@ namespace Kbg.NppPluginNET.PluginInfrastructure
         /// to rangeLength bytes.
         /// (Scintilla feature 2643)
         /// </summary>
-        int GetRangePointer(int position, int rangeLength);
+        IntPtr GetRangePointer(int position, int rangeLength);
 
         /// <summary>
         /// Return a position which, to avoid performance costs, should not be within

--- a/Visual Studio Project Template C#/PluginInfrastructure/ScintillaGateway.cs
+++ b/Visual Studio Project Template C#/PluginInfrastructure/ScintillaGateway.cs
@@ -1801,10 +1801,9 @@ namespace Kbg.NppPluginNET.PluginInfrastructure
         }
 
         /// <summary>Retrieve a pointer to a function that processes messages for this Scintilla. (Scintilla feature 2184)</summary>
-        public int GetDirectFunction()
+        public IntPtr GetDirectFunction()
         {
-            IntPtr res = Win32.SendMessage(scintilla, SciMsg.SCI_GETDIRECTFUNCTION, Unused, Unused);
-            return (int) res;
+            return Win32.SendMessage(scintilla, SciMsg.SCI_GETDIRECTFUNCTION, Unused, Unused);
         }
 
         /// <summary>
@@ -1812,10 +1811,9 @@ namespace Kbg.NppPluginNET.PluginInfrastructure
         /// the function returned by GetDirectFunction.
         /// (Scintilla feature 2185)
         /// </summary>
-        public int GetDirectPointer()
+        public IntPtr GetDirectPointer()
         {
-            IntPtr res = Win32.SendMessage(scintilla, SciMsg.SCI_GETDIRECTPOINTER, Unused, Unused);
-            return (int) res;
+            return Win32.SendMessage(scintilla, SciMsg.SCI_GETDIRECTPOINTER, Unused, Unused);
         }
 
         /// <summary>Set to overtype (true) or insert mode. (Scintilla feature 2186)</summary>
@@ -2992,14 +2990,13 @@ namespace Kbg.NppPluginNET.PluginInfrastructure
         }
 
         /// <summary>Retrieve a pointer to the document object. (Scintilla feature 2357)</summary>
-        public int GetDocPointer()
+        public IntPtr GetDocPointer()
         {
-            IntPtr res = Win32.SendMessage(scintilla, SciMsg.SCI_GETDOCPOINTER, Unused, Unused);
-            return (int) res;
+            return Win32.SendMessage(scintilla, SciMsg.SCI_GETDOCPOINTER, Unused, Unused);
         }
 
         /// <summary>Change the document object used. (Scintilla feature 2358)</summary>
-        public void SetDocPointer(int pointer)
+        public void SetDocPointer(IntPtr pointer)
         {
             IntPtr res = Win32.SendMessage(scintilla, SciMsg.SCI_SETDOCPOINTER, Unused, pointer);
         }
@@ -3936,10 +3933,9 @@ namespace Kbg.NppPluginNET.PluginInfrastructure
         /// characters in the document.
         /// (Scintilla feature 2520)
         /// </summary>
-        public int GetCharacterPointer()
+        public IntPtr GetCharacterPointer()
         {
-            IntPtr res = Win32.SendMessage(scintilla, SciMsg.SCI_GETCHARACTERPOINTER, Unused, Unused);
-            return (int) res;
+            return Win32.SendMessage(scintilla, SciMsg.SCI_GETCHARACTERPOINTER, Unused, Unused);
         }
 
         /// <summary>
@@ -3948,10 +3944,9 @@ namespace Kbg.NppPluginNET.PluginInfrastructure
         /// to rangeLength bytes.
         /// (Scintilla feature 2643)
         /// </summary>
-        public int GetRangePointer(int position, int rangeLength)
+        public IntPtr GetRangePointer(int position, int rangeLength)
         {
-            IntPtr res = Win32.SendMessage(scintilla, SciMsg.SCI_GETRANGEPOINTER, position, rangeLength);
-            return (int) res;
+            return Win32.SendMessage(scintilla, SciMsg.SCI_GETRANGEPOINTER, position, rangeLength);
         }
 
         /// <summary>

--- a/Visual Studio Project Template C#/PluginInfrastructure/Scintilla_iface.cs
+++ b/Visual Studio Project Template C#/PluginInfrastructure/Scintilla_iface.cs
@@ -26,7 +26,7 @@ namespace Kbg.NppPluginNET.PluginInfrastructure
         /// <summary>
         /// CtrlID of the window issuing the notification
         /// </summary>
-        public uint IdFrom;   
+        public IntPtr IdFrom;
 
         /// <summary>
         /// The SCN_* notification Code
@@ -46,8 +46,8 @@ namespace Kbg.NppPluginNET.PluginInfrastructure
         public int Length;                  /* SCN_MODIFIED */
         public int LinesAdded;              /* SCN_MODIFIED */
         public int Message;                 /* SCN_MACRORECORD */
-        public uint wParam;                 /* SCN_MACRORECORD */
-        public int lParam;                  /* SCN_MACRORECORD */
+        public IntPtr wParam;               /* SCN_MACRORECORD */
+        public IntPtr lParam;               /* SCN_MACRORECORD */
 
         /// <summary>
         /// 0-based index

--- a/Visual Studio Project Template C#/PluginInfrastructure/Win32.cs
+++ b/Visual Studio Project Template C#/PluginInfrastructure/Win32.cs
@@ -15,7 +15,7 @@ namespace Kbg.NppPluginNET.PluginInfrastructure
         /// at https://github.com/kbilsted/NotepadPlusPlusPluginPack.Net
         /// </summary>
         [DllImport("user32")]
-        public static extern IntPtr SendMessage(IntPtr hWnd, uint Msg, int wParam, NppMenuCmd lParam);
+        public static extern IntPtr SendMessage(IntPtr hWnd, UInt32 Msg, IntPtr wParam, [MarshalAs(UnmanagedType.LPWStr)] string lParam);
 
         /// <summary>
         /// You should try to avoid calling this method in your plugin code. Rather use one of the gateways such as 
@@ -24,7 +24,7 @@ namespace Kbg.NppPluginNET.PluginInfrastructure
         /// at https://github.com/kbilsted/NotepadPlusPlusPluginPack.Net
         /// </summary>
         [DllImport("user32")]
-        public static extern IntPtr SendMessage(IntPtr hWnd, uint Msg, int wParam, IntPtr lParam);
+        public static extern IntPtr SendMessage(IntPtr hWnd, UInt32 Msg, IntPtr wParam, [MarshalAs(UnmanagedType.LPWStr)] StringBuilder lParam);
 
         /// <summary>
         /// You should try to avoid calling this method in your plugin code. Rather use one of the gateways such as 
@@ -33,7 +33,7 @@ namespace Kbg.NppPluginNET.PluginInfrastructure
         /// at https://github.com/kbilsted/NotepadPlusPlusPluginPack.Net
         /// </summary>
         [DllImport("user32")]
-        public static extern IntPtr SendMessage(IntPtr hWnd, uint Msg, int wParam, int lParam);
+        public static extern IntPtr SendMessage(IntPtr hWnd, UInt32 Msg, IntPtr wParam, IntPtr lParam);
 
         /// <summary>
         /// You should try to avoid calling this method in your plugin code. Rather use one of the gateways such as 
@@ -42,7 +42,7 @@ namespace Kbg.NppPluginNET.PluginInfrastructure
         /// at https://github.com/kbilsted/NotepadPlusPlusPluginPack.Net
         /// </summary>
         [DllImport("user32")]
-        public static extern IntPtr SendMessage(IntPtr hWnd, uint Msg, int wParam, out int lParam);
+        public static extern IntPtr SendMessage(IntPtr hWnd, UInt32 Msg, IntPtr wParam, out IntPtr lParam);
 
         /// <summary>
         /// You should try to avoid calling this method in your plugin code. Rather use one of the gateways such as 
@@ -50,14 +50,10 @@ namespace Kbg.NppPluginNET.PluginInfrastructure
         /// If gateways are missing or incomplete, please help extend them and send your code to the project 
         /// at https://github.com/kbilsted/NotepadPlusPlusPluginPack.Net
         /// </summary>
-        [DllImport("user32")]
-        public static extern IntPtr SendMessage(IntPtr hWnd, uint Msg, IntPtr wParam, int lParam);
-        /// <summary>
-        /// You should try to avoid calling this method in your plugin code. Rather use one of the gateways such as 
-        /// <see cref="ScintillaGateway"/> or <see cref="NotepadPPGateway"/>.  
-        /// If gateways are missing or incomplete, please help extend them and send your code to the project 
-        /// at https://github.com/kbilsted/NotepadPlusPlusPluginPack.Net
-        /// </summary>
+        public static IntPtr SendMessage(IntPtr hWnd, uint Msg, int wParam, NppMenuCmd lParam)
+        {
+            return SendMessage(hWnd, (UInt32)Msg, new IntPtr(wParam), new IntPtr((uint)lParam));
+        }
 
         /// <summary>
         /// You should try to avoid calling this method in your plugin code. Rather use one of the gateways such as 
@@ -65,8 +61,10 @@ namespace Kbg.NppPluginNET.PluginInfrastructure
         /// If gateways are missing or incomplete, please help extend them and send your code to the project 
         /// at https://github.com/kbilsted/NotepadPlusPlusPluginPack.Net
         /// </summary>
-        [DllImport("user32")]
-        public static extern IntPtr SendMessage(IntPtr hWnd, uint Msg, int wParam, ref LangType lParam);
+        public static IntPtr SendMessage(IntPtr hWnd, uint Msg, int wParam, IntPtr lParam)
+        {
+            return SendMessage(hWnd, (UInt32)Msg, new IntPtr(wParam), lParam);
+        }
 
         /// <summary>
         /// You should try to avoid calling this method in your plugin code. Rather use one of the gateways such as 
@@ -74,8 +72,10 @@ namespace Kbg.NppPluginNET.PluginInfrastructure
         /// If gateways are missing or incomplete, please help extend them and send your code to the project 
         /// at https://github.com/kbilsted/NotepadPlusPlusPluginPack.Net
         /// </summary>
-        [DllImport("user32")]
-        public static extern IntPtr SendMessage(IntPtr hWnd, uint Msg, int wParam, [MarshalAs(UnmanagedType.LPWStr)] StringBuilder lParam);
+        public static IntPtr SendMessage(IntPtr hWnd, uint Msg, int wParam, int lParam)
+        {
+            return SendMessage(hWnd, (UInt32)Msg, new IntPtr(wParam), new IntPtr(lParam));
+        }
 
         /// <summary>
         /// You should try to avoid calling this method in your plugin code. Rather use one of the gateways such as 
@@ -83,8 +83,13 @@ namespace Kbg.NppPluginNET.PluginInfrastructure
         /// If gateways are missing or incomplete, please help extend them and send your code to the project 
         /// at https://github.com/kbilsted/NotepadPlusPlusPluginPack.Net
         /// </summary>
-        [DllImport("user32")]
-        public static extern IntPtr SendMessage(IntPtr hWnd, uint Msg, int wParam, [MarshalAs(UnmanagedType.LPWStr)] string lParam);
+        public static IntPtr SendMessage(IntPtr hWnd, uint Msg, int wParam, out int lParam)
+        {
+            IntPtr outVal;
+            IntPtr retval = SendMessage(hWnd, (UInt32)Msg, new IntPtr(wParam), out outVal);
+            lParam = outVal.ToInt32();
+            return retval;
+        }
 
         /// <summary>
         /// You should try to avoid calling this method in your plugin code. Rather use one of the gateways such as 
@@ -92,8 +97,10 @@ namespace Kbg.NppPluginNET.PluginInfrastructure
         /// If gateways are missing or incomplete, please help extend them and send your code to the project 
         /// at https://github.com/kbilsted/NotepadPlusPlusPluginPack.Net
         /// </summary>
-        [DllImport("user32")]
-        public static extern IntPtr SendMessage(IntPtr hWnd, uint Msg, IntPtr wParam, [MarshalAs(UnmanagedType.LPWStr)] string lParam);
+        public static IntPtr SendMessage(IntPtr hWnd, uint Msg, IntPtr wParam, int lParam)
+        {
+            return SendMessage(hWnd, (UInt32)Msg, wParam, new IntPtr(lParam));
+        }
 
         /// <summary>
         /// You should try to avoid calling this method in your plugin code. Rather use one of the gateways such as 
@@ -101,28 +108,10 @@ namespace Kbg.NppPluginNET.PluginInfrastructure
         /// If gateways are missing or incomplete, please help extend them and send your code to the project 
         /// at https://github.com/kbilsted/NotepadPlusPlusPluginPack.Net
         /// </summary>
-        [DllImport("user32")]
-        public static extern IntPtr SendMessage(IntPtr hWnd, uint Msg, IntPtr wParam, [MarshalAs(UnmanagedType.LPWStr)] StringBuilder lParam);
-
-
-        // TODO KBG Experimental
-        /// <summary>
-        /// You should try to avoid calling this method in your plugin code. Rather use one of the gateways such as 
-        /// <see cref="ScintillaGateway"/> or <see cref="NotepadPPGateway"/>.  
-        /// If gateways are missing or incomplete, please help extend them and send your code to the project 
-        /// at https://github.com/kbilsted/NotepadPlusPlusPluginPack.Net
-        /// </summary>
-        [DllImport("user32")]
-        public static extern IntPtr SendMessage(IntPtr hWnd, SciMsg Msg, IntPtr wParam, IntPtr lParam);
-        /// <summary>
-        /// You should try to avoid calling this method in your plugin code. Rather use one of the gateways such as 
-        /// <see cref="ScintillaGateway"/> or <see cref="NotepadPPGateway"/>.  
-        /// If gateways are missing or incomplete, please help extend them and send your code to the project 
-        /// at https://github.com/kbilsted/NotepadPlusPlusPluginPack.Net
-        /// </summary>
-        [DllImport("user32")]
-        public static extern IntPtr SendMessage(IntPtr hWnd, SciMsg Msg, IntPtr wParam, int lParam);
-
+        public static IntPtr SendMessage(IntPtr hWnd, uint Msg, int wParam, [MarshalAs(UnmanagedType.LPWStr)] StringBuilder lParam)
+        {
+            return SendMessage(hWnd, (UInt32)Msg, new IntPtr(wParam), lParam);
+        }
 
         /// <summary>
         /// You should try to avoid calling this method in your plugin code. Rather use one of the gateways such as 
@@ -130,8 +119,10 @@ namespace Kbg.NppPluginNET.PluginInfrastructure
         /// If gateways are missing or incomplete, please help extend them and send your code to the project 
         /// at https://github.com/kbilsted/NotepadPlusPlusPluginPack.Net
         /// </summary>
-        [DllImport("user32")]
-        public static extern IntPtr SendMessage(IntPtr hWnd, SciMsg Msg, int wParam, IntPtr lParam);
+        public static IntPtr SendMessage(IntPtr hWnd, uint Msg, int wParam, [MarshalAs(UnmanagedType.LPWStr)] string lParam)
+        {
+            return SendMessage(hWnd, (UInt32)Msg, new IntPtr(wParam), lParam);
+        }
 
         /// <summary>
         /// You should try to avoid calling this method in your plugin code. Rather use one of the gateways such as 
@@ -139,8 +130,10 @@ namespace Kbg.NppPluginNET.PluginInfrastructure
         /// If gateways are missing or incomplete, please help extend them and send your code to the project 
         /// at https://github.com/kbilsted/NotepadPlusPlusPluginPack.Net
         /// </summary>
-        [DllImport("user32")]
-        public static extern IntPtr SendMessage(IntPtr hWnd, SciMsg Msg, int wParam, string lParam);
+        public static IntPtr SendMessage(IntPtr hWnd, SciMsg Msg, IntPtr wParam, int lParam)
+        {
+            return SendMessage(hWnd, (UInt32)Msg, wParam, new IntPtr(lParam));
+        }
 
         /// <summary>
         /// You should try to avoid calling this method in your plugin code. Rather use one of the gateways such as 
@@ -148,8 +141,10 @@ namespace Kbg.NppPluginNET.PluginInfrastructure
         /// If gateways are missing or incomplete, please help extend them and send your code to the project 
         /// at https://github.com/kbilsted/NotepadPlusPlusPluginPack.Net
         /// </summary>
-        [DllImport("user32")]
-        public static extern IntPtr SendMessage(IntPtr hWnd, SciMsg Msg, int wParam, [MarshalAs(UnmanagedType.LPStr)] StringBuilder lParam);
+        public static IntPtr SendMessage(IntPtr hWnd, SciMsg Msg, int wParam, IntPtr lParam)
+        {
+            return SendMessage(hWnd, (UInt32)Msg, new IntPtr(wParam), lParam);
+        }
 
         /// <summary>
         /// You should try to avoid calling this method in your plugin code. Rather use one of the gateways such as 
@@ -157,8 +152,57 @@ namespace Kbg.NppPluginNET.PluginInfrastructure
         /// If gateways are missing or incomplete, please help extend them and send your code to the project 
         /// at https://github.com/kbilsted/NotepadPlusPlusPluginPack.Net
         /// </summary>
-        [DllImport("user32")]
-        public static extern IntPtr SendMessage(IntPtr hWnd, SciMsg Msg, int wParam, int lParam);
+        public static IntPtr SendMessage(IntPtr hWnd, SciMsg Msg, int wParam, string lParam)
+        {
+            return SendMessage(hWnd, (UInt32)Msg, new IntPtr(wParam), lParam);
+        }
+
+        /// <summary>
+        /// You should try to avoid calling this method in your plugin code. Rather use one of the gateways such as 
+        /// <see cref="ScintillaGateway"/> or <see cref="NotepadPPGateway"/>.  
+        /// If gateways are missing or incomplete, please help extend them and send your code to the project 
+        /// at https://github.com/kbilsted/NotepadPlusPlusPluginPack.Net
+        /// </summary>
+        public static IntPtr SendMessage(IntPtr hWnd, SciMsg Msg, int wParam, [MarshalAs(UnmanagedType.LPStr)] StringBuilder lParam)
+        {
+            return SendMessage(hWnd, (UInt32)Msg, new IntPtr(wParam), lParam);
+        }
+
+        /// <summary>
+        /// You should try to avoid calling this method in your plugin code. Rather use one of the gateways such as 
+        /// <see cref="ScintillaGateway"/> or <see cref="NotepadPPGateway"/>.  
+        /// If gateways are missing or incomplete, please help extend them and send your code to the project 
+        /// at https://github.com/kbilsted/NotepadPlusPlusPluginPack.Net
+        /// </summary>
+        public static IntPtr SendMessage(IntPtr hWnd, SciMsg Msg, int wParam, int lParam)
+        {
+            return SendMessage(hWnd, (UInt32)Msg, new IntPtr(wParam), new IntPtr(lParam));
+        }
+
+        /// <summary>
+        /// You should try to avoid calling this method in your plugin code. Rather use one of the gateways such as 
+        /// <see cref="ScintillaGateway"/> or <see cref="NotepadPPGateway"/>.  
+        /// If gateways are missing or incomplete, please help extend them and send your code to the project 
+        /// at https://github.com/kbilsted/NotepadPlusPlusPluginPack.Net
+        /// </summary>
+        public static IntPtr SendMessage(IntPtr hWnd, SciMsg Msg, IntPtr wParam, IntPtr lParam)
+        {
+            return SendMessage(hWnd, (UInt32)Msg, wParam, lParam);
+        }
+
+        /// <summary>
+        /// You should try to avoid calling this method in your plugin code. Rather use one of the gateways such as
+        /// <see cref="ScintillaGateway"/> or <see cref="NotepadPPGateway"/>.
+        /// If gateways are missing or incomplete, please help extend them and send your code to the project
+        /// at https://github.com/kbilsted/NotepadPlusPlusPluginPack.Net
+        /// </summary>
+	public static IntPtr SendMessage(IntPtr hWnd, uint Msg, int wParam, ref LangType lParam)
+        {
+            IntPtr outVal;
+            IntPtr retval = SendMessage(hWnd, (UInt32)Msg, new IntPtr(wParam), out outVal);
+            lParam = (LangType)outVal;
+            return retval;
+        }
 
         public const int MAX_PATH = 260;
 


### PR DESCRIPTION
This change makes plugins actually work with Notepad++ 64-bit builds. However, one missing piece is the [UnmanagedExports](https://www.nuget.org/packages/UnmanagedExports/1.2.7) package from nuget. A change is still needed to replace the included DllExports with a dependency on [UnmanagedExports](https://www.nuget.org/packages/UnmanagedExports/1.2.7). Makes progress on fixing #21.