### PR TITLE
Changed: ScintillaGateway GetText method now uses length for its byte…

### DIFF
--- a/Visual Studio Project Template C#/PluginInfrastructure/ScintillaGateway.cs
+++ b/Visual Studio Project Template C#/PluginInfrastructure/ScintillaGateway.cs
@@ -1785,7 +1785,7 @@ namespace Kbg.NppPluginNET.PluginInfrastructure
         /// </summary>
         public unsafe string GetText(int length)
         {
-            byte[] textBuffer = new byte[10000];
+            byte[] textBuffer = new byte[length];
             fixed (byte* textPtr = textBuffer)
             {
                 IntPtr res = Win32.SendMessage(scintilla, SciMsg.SCI_GETTEXT, length, (IntPtr) textPtr);


### PR DESCRIPTION
…-array return value, as strings/texts in the editor could be longer/bigger

Hi kbilsted

I changed the *GetText* method in the way that the fixed size byte[] array used for the return value is now using the length given. The fixed byte[] lead to issues, especially with big/long documents killing the whole instance.

Just using length might not be the most ideal and can be optimized maybe, but won't lead to crashes anymore for now. 


Cheers