### PR TITLE
x86 and x64 works, including debugging

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This is a fork of UFO's plugin package updated for VS2015
 ## Getting started
   1. Download a [release](https://github.com/kbilsted/NotepadPlusPlusPluginPack.Net/releases/) 
   2. Place the visual studio project template (the `NppPlugin.zip`) in the visual studio path (typically `"My Documents\Visual Studio 2015\Templates\ProjectTemplates\Visual C#\"`)
-  3. Ensure you have installed **Visual C++** from the visual studio installer otherwise your project wont build<br>
+  3. If you intend to debug Notepad++ itself (and not just the plugin) ensure you have installed **Visual C++** from the visual studio installer<br>
   ![install CPP](/documentation/installcpp.png)
   4. Create a new project inside Visual studio using `file -> new -> project -> visual C# -> Notepad++ project`
   5. Build (building will copy the dll to the `Notepad++/plugins` folder)
@@ -39,6 +39,7 @@ This is a fork of UFO's plugin package updated for VS2015
   * https://github.com/kbilsted/NppPluginRebaseAssister
   * https://github.com/nea/MarkdownViewerPlusPlus
   * https://github.com/AnnaVel/RtfHelper
+  * https://github.com/jokedst/CsvQuery
   
 If your plugin is not on the list, please make a PR with a link to it.. :-)
 
@@ -76,9 +77,17 @@ The architecture of the plugin is.
                        +-----------+ 
 
 ### How to debug plugins
+  * Install both 32 bit and 64 bit versions of Notepad++ (if you intend to publish for both)
+  * Give yourself write permissions to the Notepad++ plugin folders
+    * Usually `C:\Program Files (x86)\Notepad++\plugins\` (for 32 bit) and `C:\Program Files\Notepad++\plugins\` (for 64 bit)
+    * Or run Visual Studio as administrator (not recommended)
+  * In Visual Studio, choose Platform to debug (x86 or x64)
+  * Make sure Notepad++ is not running
+  * Start Debugging (F5 by default)
 
+Or you can attach to a running process:
   * start notepad++
-  * in Visualstudio: debug -> attach to process... -> notepad++.exe
+  * in Visual Studio: debug -> attach to process... -> notepad++.exe
 
 you can now set breakpoints and step-execute. (currently not working in v6.9.2 https://github.com/notepad-plus-plus/notepad-plus-plus/issues/1964) 
   
@@ -106,6 +115,14 @@ To use included references in your compiled plugin you need to merge these into 
 The best way is to install [MSBuild.ILMerge.Task][1] via NuGet in your plugin project. It will include [ILMerge][2] as dependency and attach itself to your Visual Studio build process. By that, with every build you compile a merged plugin *.dll* including all your custom references to use. ILMerge will add configuration files to your project: *ILMerge.props* and *ILMergeOrder.txt*. Refer to the official homepage for more information about the configuration possibilities.
 
 *Note: To use ILMerge in your plugin you have to change the **Target Framework** of your plugin project to at least .NET Framework 4.0 (CP). ILMerge can work with .NET 3.5 and below, but requires additional configuration and adaptation. If you do not required the extreme backwards compatibility, upgrade the .NET Framework target as quick and easy solution.*
+
+### 32 vs 64 bit
+Notepad++ comes in two versions, 32 bit and 64 bit. Unfortunately this means plugins need to create two versions as well.
+
+Using this template you can switch between the two using the Visual Studio "Target Platform" drop-down.
+
+When publishing your plugin you should build in Release mode for both x86 and x64 and publish both resulting dll's (e.g. `bin/Release/myPlugin.dll` and `/bin/Release-x64/MyPlugin.dll`)
+
 
 ## Versioning
 Until we reach v1.0 expect a bit of chaos and breaking changes.

--- a/Visual Studio Project Template C#/$projectname$.csproj
+++ b/Visual Studio Project Template C#/$projectname$.csproj
@@ -50,6 +50,8 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup>
+    <!-- Default values for debugging sso it start correct version of Notepad++
+         $(ProgramW6432) and $(MSBuildProgramFiles32) points to the 64 and 32 bit "Program Files" directories -->
     <StartAction>Program</StartAction>
     <StartProgram Condition="'$(Platform)'=='x64'">$(ProgramW6432)\Notepad++\notepad++.exe</StartProgram>
     <StartProgram Condition="'$(Platform)'=='x86'">$(MSBuildProgramFiles32)\Notepad++\notepad++.exe</StartProgram>

--- a/Visual Studio Project Template C#/$projectname$.csproj
+++ b/Visual Studio Project Template C#/$projectname$.csproj
@@ -3,21 +3,15 @@
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">x86</Platform>
-    <SchemaVersion>2.0</SchemaVersion>
-    <ProjectGuid>{E56F6E12-089C-40ED-BCFD-923E5FA121A1}</ProjectGuid>
+    <ProjectGuid>{$guid1$}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>$safeprojectname$</RootNamespace>
     <AssemblyName>$safeprojectname$</AssemblyName>
     <OutputPath>bin\Debug\</OutputPath>
-    <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
-    <FileUpgradeFlags>
-    </FileUpgradeFlags>
-    <UpgradeBackupLocation>
-    </UpgradeBackupLocation>
-    <OldToolsVersion>3.5</OldToolsVersion>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
     <DebugSymbols>true</DebugSymbols>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <DebugType>full</DebugType>
@@ -27,7 +21,7 @@
     <PlatformTarget>x86</PlatformTarget>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x86' ">
     <DefineConstants>TRACE</DefineConstants>
     <Optimize>true</Optimize>
     <OutputPath>bin\Release</OutputPath>
@@ -35,6 +29,30 @@
     <ErrorReport>prompt</ErrorReport>
     <PlatformTarget>x86</PlatformTarget>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x64' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <DebugType>full</DebugType>
+    <ErrorReport>prompt</ErrorReport>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug-x64</OutputPath>
+    <PlatformTarget>x64</PlatformTarget>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x64' ">
+    <DefineConstants>TRACE</DefineConstants>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release-x64</OutputPath>
+    <DebugType>pdbonly</DebugType>
+    <ErrorReport>prompt</ErrorReport>
+    <PlatformTarget>x64</PlatformTarget>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+  <PropertyGroup>
+    <StartAction>Program</StartAction>
+    <StartProgram Condition="'$(Platform)'=='x64'">$(ProgramW6432)\Notepad++\notepad++.exe</StartProgram>
+    <StartProgram Condition="'$(Platform)'=='x86'">$(MSBuildProgramFiles32)\Notepad++\notepad++.exe</StartProgram>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/Visual Studio Project Template C#/PluginInfrastructure/DllExport/NppPlugin.DllExport.targets
+++ b/Visual Studio Project Template C#/PluginInfrastructure/DllExport/NppPlugin.DllExport.targets
@@ -6,6 +6,8 @@
           DependsOnTargets="GetFrameworkPaths"
           >
     <PropertyGroup>
+		<!-- LibToolPath is optional - it's needed to debug C++, but you can still debug the C# code without it
+			If you don't have the C++ toolchain installed this is missing, but then you can't' debug C++ anyway -->
         <LibToolPath Condition="Exists('$(DevEnvDir)\..\..\VC\bin')">$(DevEnvDir)\..\..\VC\bin</LibToolPath>
     </PropertyGroup>
     <DllExportTask Platform="$(Platform)"
@@ -24,6 +26,10 @@
                    LibToolDllPath="$(DevEnvDir)"
                    SdkPath="$(SDK40ToolsPath)"/>
  
+	<!-- $(MSBuildProgramFiles32) points to the 32 bit program files dir.
+		On 32 bit windows usually C:\Program Files\
+		On 64 bit windows usually C:\Program Files (x86)\
+		$(ProgramW6432) points to the 64bit Program Files (on 32 bit windows it is blank) -->
     <Copy 
         SourceFiles="$(TargetPath)" 
         DestinationFolder="$(MSBuildProgramFiles32)\Notepad++\plugins\" 

--- a/Visual Studio Project Template C#/PluginInfrastructure/DllExport/NppPlugin.DllExport.targets
+++ b/Visual Studio Project Template C#/PluginInfrastructure/DllExport/NppPlugin.DllExport.targets
@@ -5,6 +5,9 @@
   <Target Name="AfterBuild"
           DependsOnTargets="GetFrameworkPaths"
           >
+    <PropertyGroup>
+        <LibToolPath Condition="Exists('$(DevEnvDir)\..\..\VC\bin')">$(DevEnvDir)\..\..\VC\bin</LibToolPath>
+    </PropertyGroup>
     <DllExportTask Platform="$(Platform)"
                    PlatformTarget="$(PlatformTarget)"
                    CpuType="$(CpuType)"
@@ -17,14 +20,19 @@
                    ProjectDirectory="$(MSBuildProjectDirectory)"
                    InputFileName="$(TargetPath)"
                    FrameworkPath="$(TargetedFrameworkDir);$(TargetFrameworkDirectory)"
-                   LibToolPath="$(DevEnvDir)\..\..\VC\bin"
+                   LibToolPath="$(LibToolPath)"
                    LibToolDllPath="$(DevEnvDir)"
                    SdkPath="$(SDK40ToolsPath)"/>
  
     <Copy 
         SourceFiles="$(TargetPath)" 
-        DestinationFolder="C:\Program Files (x86)\Notepad++\plugins\" 
-        Condition="Exists('C:\Program Files (x86)\Notepad++\plugins\')"
+        DestinationFolder="$(MSBuildProgramFiles32)\Notepad++\plugins\" 
+        Condition="Exists('$(MSBuildProgramFiles32)\Notepad++\plugins\') AND '$(Platform)'=='x86'"
+        ContinueOnError="false" /> 
+    <Copy 
+        SourceFiles="$(TargetPath)" 
+        DestinationFolder="$(ProgramW6432)\Notepad++\plugins\" 
+        Condition="Exists('$(ProgramW6432)\Notepad++\plugins\') AND '$(Platform)'=='x64'"
         ContinueOnError="false" />
   </Target>
 </Project>


### PR DESCRIPTION
I thought I'd present my alternative way to make NPPPP x64-bit compatible.

It removes LibPath (if it doesn't exist, like on my machine) since the only difference is that I can't debug C++ code (e.g. Notepad++ itself).
It upgrades to 4.0, just like Oleg.

Then it simply replaces the AnyCPU target with a x86 and a x64 target.
I included default values for debug start, so if you press F5 in x86 mode it starts 32 bit Notepad++, and in x64-mode it starts Notepad++ 64 bit (requires you have both installed and makes their "plugins" directory writable to yourself)