### PR TITLE
Edit NppPlugin.DllExport.targets to support new Notepad++ plugins directory structure.

### DIFF
--- a/Visual Studio Project Template C#/PluginInfrastructure/DllExport/NppPlugin.DllExport.targets
+++ b/Visual Studio Project Template C#/PluginInfrastructure/DllExport/NppPlugin.DllExport.targets
@@ -30,15 +30,17 @@
 		On 32 bit windows usually C:\Program Files\
 		On 64 bit windows usually C:\Program Files (x86)\
 		$(ProgramW6432) points to the 64bit Program Files (on 32 bit windows it is blank) -->
+    <MakeDir Directories="$(MSBuildProgramFiles32)\Notepad++\plugins\$(TargetName)\" Condition="Exists('$(MSBuildProgramFiles32)\Notepad++\plugins\') AND !Exists('$(MSBuildProgramFiles32)\Notepad++\plugins\$(TargetName)\') AND '$(Platform)'=='x86'" />
     <Copy 
         SourceFiles="$(TargetPath)" 
-        DestinationFolder="$(MSBuildProgramFiles32)\Notepad++\plugins\" 
-        Condition="Exists('$(MSBuildProgramFiles32)\Notepad++\plugins\') AND '$(Platform)'=='x86'"
-        ContinueOnError="false" /> 
+        DestinationFolder="$(MSBuildProgramFiles32)\Notepad++\plugins\$(TargetName)\)" 
+        Condition="Exists('$(MSBuildProgramFiles32)\Notepad++\plugins\$(TargetName)\') AND '$(Platform)'=='x86'"
+        ContinueOnError="false" />
+    <MakeDir Directories="$(ProgramW6432)\Notepad++\plugins\$(TargetName)\" Condition="Exists('$(ProgramW6432)\Notepad++\plugins\') AND !Exists('$(ProgramW6432)\Notepad++\plugins\$(TargetName)\') AND '$(Platform)'=='x64'" />
     <Copy 
         SourceFiles="$(TargetPath)" 
-        DestinationFolder="$(ProgramW6432)\Notepad++\plugins\" 
-        Condition="Exists('$(ProgramW6432)\Notepad++\plugins\') AND '$(Platform)'=='x64'"
+        DestinationFolder="$(ProgramW6432)\Notepad++\plugins\$(TargetName)\" 
+        Condition="Exists('$(ProgramW6432)\Notepad++\plugins\$(TargetName)\') AND '$(Platform)'=='x64'"
         ContinueOnError="false" />
   </Target>
 </Project>

--- a/Visual Studio Project Template C#/PluginInfrastructure/DllExport/NppPlugin.DllExport.targets
+++ b/Visual Studio Project Template C#/PluginInfrastructure/DllExport/NppPlugin.DllExport.targets
@@ -33,7 +33,7 @@
     <MakeDir Directories="$(MSBuildProgramFiles32)\Notepad++\plugins\$(TargetName)\" Condition="Exists('$(MSBuildProgramFiles32)\Notepad++\plugins\') AND !Exists('$(MSBuildProgramFiles32)\Notepad++\plugins\$(TargetName)\') AND '$(Platform)'=='x86'" />
     <Copy 
         SourceFiles="$(TargetPath)" 
-        DestinationFolder="$(MSBuildProgramFiles32)\Notepad++\plugins\$(TargetName)\)" 
+        DestinationFolder="$(MSBuildProgramFiles32)\Notepad++\plugins\$(TargetName)\" 
         Condition="Exists('$(MSBuildProgramFiles32)\Notepad++\plugins\$(TargetName)\') AND '$(Platform)'=='x86'"
         ContinueOnError="false" />
     <MakeDir Directories="$(ProgramW6432)\Notepad++\plugins\$(TargetName)\" Condition="Exists('$(ProgramW6432)\Notepad++\plugins\') AND !Exists('$(ProgramW6432)\Notepad++\plugins\$(TargetName)\') AND '$(Platform)'=='x64'" />


### PR DESCRIPTION
Hello in the new version of Notepad++ plugins need to be placed in sub directories.

I edited the NppPlugin.DllExport.targets to create the subdirectory if not exists and to copy the plugin in it.

By the way NotepadPlusPlusPluginPack.Net is just awesome.
Thanks for it.