### PR TITLE
Use length for buffer size if available

### DIFF
--- a/ToolsForMaintainersOfTheProjectTemplate/Scintilla_iface_synchronizer/cs.py
+++ b/ToolsForMaintainersOfTheProjectTemplate/Scintilla_iface_synchronizer/cs.py
@@ -171,7 +171,8 @@ def printLexGatewayFile(f):
 				
 			if param2Type == "stringresult":
 				bufferVariableName = param2Name + "Buffer"
-				out.append(iindent + "byte[] " + bufferVariableName +" = new byte[10000];")
+				bufferSize = "length" if (param1Type == "int" and param1Name == "length") else "10000"
+				out.append(iindent + "byte[] " + bufferVariableName +" = new byte["+bufferSize+"];")
 				out.append(iindent + "fixed (byte* "+param2Name+"Ptr = " +bufferVariableName + ")" )
 				out.append(iindent + "{")
 				iindent = iindent + "    "


### PR DESCRIPTION
May addresses the issues #28 #38 #42 

Previously the length was ignored which could lead to crashes for large documents
```
public unsafe string GetText(int length)
{
    byte[] textBuffer = new byte[10000];
```

The fix uses the length parameter for the buffer if available:
```
public unsafe string GetText(int length)
{
    byte[] textBuffer = new byte[length];
```
