### PR TITLE
Use IntPtr for TextRange to support x86 and x64

### DIFF
--- a/Visual Studio Project Template C#/PluginInfrastructure/GatewayDomain.cs
+++ b/Visual Studio Project Template C#/PluginInfrastructure/GatewayDomain.cs
@@ -188,9 +188,9 @@ namespace Kbg.NppPluginNET.PluginInfrastructure
     [StructLayout(LayoutKind.Sequential)]
     public struct CharacterRange
     {
-        public CharacterRange(int cpmin, int cpmax) { cpMin = cpmin; cpMax = cpmax; }
-        public int cpMin;
-        public int cpMax;
+        public CharacterRange(int cpmin, int cpmax) { cpMin = new IntPtr(cpmin); cpMax = new IntPtr(cpmax); }
+        public IntPtr cpMin;
+        public IntPtr cpMax;
     }
 
     public class Cells
@@ -217,8 +217,8 @@ namespace Kbg.NppPluginNET.PluginInfrastructure
         }
         public TextRange(int cpmin, int cpmax, int stringCapacity)
         {
-            _sciTextRange.chrg.cpMin = cpmin;
-            _sciTextRange.chrg.cpMax = cpmax;
+            _sciTextRange.chrg.cpMin = new IntPtr(cpmin);
+            _sciTextRange.chrg.cpMax = new IntPtr(cpmax);
             _sciTextRange.lpstrText = Marshal.AllocHGlobal(stringCapacity);
         }
 

--- a/Visual Studio Project Template C#/PluginInfrastructure/Scintilla_iface.cs
+++ b/Visual Studio Project Template C#/PluginInfrastructure/Scintilla_iface.cs
@@ -3232,8 +3232,8 @@ namespace Kbg.NppPluginNET.PluginInfrastructure
         /// <param name="searchText">the search pattern</param>
         public TextToFind(int cpmin, int cpmax, string searchText)
         {
-            _sciTextToFind.chrg.cpMin = cpmin;
-            _sciTextToFind.chrg.cpMax = cpmax;
+            _sciTextToFind.chrg.cpMin = new IntPtr(cpmin);
+            _sciTextToFind.chrg.cpMax = new IntPtr(cpmax);
             _sciTextToFind.lpstrText = Marshal.StringToHGlobalAnsi(searchText);
         }
 


### PR DESCRIPTION
Fix for #74 #84

Works for x86 but crashes on for x64:
`TextRange textRange = new TextRange(0, -1, 1000)`

After modifying to `IntPtr` it runs for both architectures:
`TextRange textRange = new TextRange(new IntPtr(0), new IntPtr(-1), 1000)`