### PR TITLE
Fixed GetCurrentFilePath due to unexpected return value

### DIFF
--- a/Visual Studio Project Template C#/PluginInfrastructure/NotepadPPGateway.cs
+++ b/Visual Studio Project Template C#/PluginInfrastructure/NotepadPPGateway.cs
@@ -60,7 +60,11 @@ namespace Kbg.NppPluginNET.PluginInfrastructure
 		/// Gets the path of the current document.
 		/// </summary>
 		public string GetCurrentFilePath()
-			=> GetString(NppMsg.NPPM_GETFULLCURRENTPATH);
+		{
+			var path = new StringBuilder(2000);
+			Win32.SendMessage(PluginBase.nppData._nppHandle, (uint)NppMsg.NPPM_GETFULLCURRENTPATH, 0, path);
+			return path.ToString();
+		}
 
 		/// <summary>
 		/// This method incapsulates a common pattern in the Notepad++ API: when


### PR DESCRIPTION
Please have a look at the doc for _NPPM_GETFULLCURRENTPATH_ at https://npp-user-manual.org/docs/plugin-communication/.
Return value is not the string length.