### PR TITLE
Add patch for NaN, Inf compiler errors, quality-of-life improvement in WhatIsNpp

### DIFF
--- a/Demo Plugin/NppManagedPluginDemo/Demo.cs
+++ b/Demo Plugin/NppManagedPluginDemo/Demo.cs
@@ -136,6 +136,7 @@ namespace Kbg.Demo.Namespace
             PluginBase.SetCommand(16, "---", null);
 
             PluginBase.SetCommand(17, "Print Scroll and Row Information", PrintScrollInformation);
+            PluginBase.SetCommand(18, "Use NanInf class for -inf, inf, nan!!", PrintNanInf);
         }
 
         /// <summary>
@@ -410,6 +411,21 @@ The current scroll ratio is {Math.Round(scrollPercentage, 2)}%.
             string sessionPath = Marshal.PtrToStringUni(Win32.SendMessage(PluginBase.nppData._nppHandle, (uint) NppMsg.NPPM_SAVECURRENTSESSION, 0, sessionFilePath));
             if (!string.IsNullOrEmpty(sessionPath))
                 MessageBox.Show(sessionPath, "Saved Session File :", MessageBoxButtons.OK);
+        }
+
+        static void PrintNanInf()
+        {
+            string naninf = $@"-infinity = NanInf.neginf = {NanInf.neginf}
+infinity = NanInf.inf = {NanInf.inf}
+NaN = NanInf.nan = {NanInf.nan}
+
+If you want these constants in your plugin, you can find them in the NanInf class in PluginInfrastructure.
+
+DO NOT USE double.PositiveInfinity, double.NegativeInfinity, or double.NaN.
+You will get a compiler error if you do.    ";
+            MessageBox.Show(naninf, "Use the NanInf class for NaN, -inf, inf!", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+            notepad.FileNew();
+            editor.AppendTextAndMoveCursor(naninf);
         }
 
         static void DockableDlgDemo()

--- a/Demo Plugin/NppManagedPluginDemo/NppManagedPluginDemo.csproj
+++ b/Demo Plugin/NppManagedPluginDemo/NppManagedPluginDemo.csproj
@@ -121,6 +121,7 @@
       <DependentUpon>frmGoToLine.cs</DependentUpon>
     </Compile>
     <Compile Include="Demo.cs" />
+    <Compile Include="PluginInfrastructure\NanInf.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Properties\Resources.Designer.cs">
       <DependentUpon>Resources.resx</DependentUpon>

--- a/Demo Plugin/NppManagedPluginDemo/PluginInfrastructure/NanInf.cs
+++ b/Demo Plugin/NppManagedPluginDemo/PluginInfrastructure/NanInf.cs
@@ -1,0 +1,30 @@
+﻿using System;
+
+namespace Kbg.NppPluginNET.PluginInfrastructure
+{
+    /// <summary>
+    /// holds NaN, Infinity, and -Infinity as things generated at runtime<br></br>
+    /// because the compiler freaks out if it sees any of<br></br>
+    /// double.NegativeInfinity, double.PositiveInfinity, or double.NaN<br></br>
+    /// or any statically analyzed function of two constants that makes one of those constants<br></br>
+    /// like 1d/0d, 0d/0d, or -1d/0d.
+    /// </summary>
+    public class NanInf
+    {
+        /// <summary>
+        /// a/b<br></br>
+        /// may be necessary to generate infinity or nan at runtime
+        /// to avoid the compiler pre-computing things<br></br>
+        /// since if the compiler sees literal 1d/0d in the code
+        /// it just pre-computes it at compile time
+        /// </summary>
+        /// <param name="a"></param>
+        /// <param name="b"></param>
+        /// <returns></returns>
+        public static double Divide(double a, double b) { return a / b; }
+
+        public static readonly double inf = Divide(1d, 0d);
+        public static readonly double neginf = Divide(-1d, 0d);
+        public static readonly double nan = Divide(0d, 0d);
+    }
+}

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ This is a fork of UFO's plugin package updated for VS2015, 2017 and 2019
   * https://github.com/wakatime/notepadpp-wakatime
   * https://github.com/alex-ilin/WebEdit
   * https://github.com/Fruchtzwerg94/PlantUmlViewer
+  * https://github.com/molsonkiko/JsonToolsNppPlugin
   
 If your plugin is not on the list, please make a PR with a link to it.. :-)
 

--- a/Visual Studio Project Template C#/PluginInfrastructure/IScintillaGateway.cs
+++ b/Visual Studio Project Template C#/PluginInfrastructure/IScintillaGateway.cs
@@ -2516,7 +2516,10 @@ namespace Kbg.NppPluginNET.PluginInfrastructure
         /// <summary>Set up the key words used by the lexer. (Scintilla feature 4005)</summary>
         unsafe void SetKeyWords(int keyWordSet, string keyWords);
 
-        /// <summary>Set the lexing language of the document based on string name. (Scintilla feature 4006)</summary>
+        /// <summary>Set the lexing language of the document based on string name. (Scintilla feature 4006)<br></br>
+        /// WARNING! This does not appear to do anything.<br></br>
+        /// Use INotepadPPGateway.SetCurrentLanguage instead.
+        /// </summary>
         unsafe void SetLexerLanguage(string language);
 
         /// <summary>Load a lexer library (dll / so). (Scintilla feature 4007)</summary>

--- a/Visual Studio Project Template C#/PluginInfrastructure/NotepadPPGateway.cs
+++ b/Visual Studio Project Template C#/PluginInfrastructure/NotepadPPGateway.cs
@@ -16,7 +16,7 @@ namespace Kbg.NppPluginNET.PluginInfrastructure
 		string GetNppPath();
 		string GetPluginConfigPath();
 		string GetCurrentFilePath();
-		unsafe string GetFilePath(int bufferId);
+		unsafe string GetFilePath(IntPtr bufferId); // use IntPtr to work with 32-bit and 64-bit Notepad++
 		void SetCurrentLanguage(LangType language);
 		bool OpenFile(string path);
 	}
@@ -108,7 +108,7 @@ namespace Kbg.NppPluginNET.PluginInfrastructure
 		/// <summary>
 		/// Gets the path of the current document.
 		/// </summary>
-		public unsafe string GetFilePath(int bufferId)
+		public unsafe string GetFilePath(IntPtr bufferId)
 		{
 			var path = new StringBuilder(2000);
 			Win32.SendMessage(PluginBase.nppData._nppHandle, (uint) NppMsg.NPPM_GETFULLPATHFROMBUFFERID, bufferId, path);


### PR DESCRIPTION
As noted in issue #93, some dependency in the project causes compiler errors if the compiler sees `double.Infinity`, `double.NegativeInfinity`, `double.NaN`, or anything else like `1d / 0d` that can be compiled to one of those via static analysis.

The NanInf class would solve that simply by safely creating those at runtime. I added a menu command with information on these errors and how to use the class. It's a crude and inelegant solution, but it works.

I also replaced insertCurrentPath with getCurrentPath, so you can get the current absolute file path as a string. I used this to periodically check the active file in whatIsNpp so that changing the active file stops the printing of text.

I changed the argument type for `NotepadPPGateway.GetFilePath` from `int` to `IntPtr` to ensure that it can handle the 64-bit buffer ID's made by 64-bit Notepad++, and also added a new plugin command, `Show files closed this session`, to illustrate how this method can be used to register the name of a file when it's closed (since the user might close a file other than the currently open file).

I flagged IScintillaGateway.SetLexerLanguage as not working and indicated that people should use INotepadPPGateway.SetCurrentLanguage instead.
Nothing groundbreaking, but I think it's probably good to have.