### PR TITLE
Replaced deprecated NPPM_ADDTOOLBARICON

### DIFF
--- a/Visual Studio Project Template C#/PluginInfrastructure/NotepadPPGateway.cs
+++ b/Visual Studio Project Template C#/PluginInfrastructure/NotepadPPGateway.cs
@@ -41,7 +41,7 @@ namespace Kbg.NppPluginNET.PluginInfrastructure
 				Marshal.StructureToPtr(icon, pTbIcons, false);
 				_ = Win32.SendMessage(
 					PluginBase.nppData._nppHandle,
-                    (uint) NppMsg.NPPM_ADDTOOLBARICON_FORDARKMODE,
+					(uint) NppMsg.NPPM_ADDTOOLBARICON_FORDARKMODE,
 					PluginBase._funcItems.Items[funcItemsIndex]._cmdID,
 					pTbIcons);
 			} finally {

--- a/Visual Studio Project Template C#/PluginInfrastructure/NotepadPPGateway.cs
+++ b/Visual Studio Project Template C#/PluginInfrastructure/NotepadPPGateway.cs
@@ -41,7 +41,7 @@ namespace Kbg.NppPluginNET.PluginInfrastructure
 				Marshal.StructureToPtr(icon, pTbIcons, false);
 				_ = Win32.SendMessage(
 					PluginBase.nppData._nppHandle,
-					(uint) NppMsg.NPPM_ADDTOOLBARICON,
+                    (uint) NppMsg.NPPM_ADDTOOLBARICON_FORDARKMODE,
 					PluginBase._funcItems.Items[funcItemsIndex]._cmdID,
 					pTbIcons);
 			} finally {


### PR DESCRIPTION
Replaced deprecated NPPM_ADDTOOLBARICON with NPPM_ADDTOOLBARICON_FORDARKMODE to support dark mode icons