### PR TITLE
- appveyor.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+
+ # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/CI_build.yml
+++ b/.github/workflows/CI_build.yml
@@ -1,0 +1,19 @@
+name: CI_build
+
+on: [push, pull_request]
+
+jobs:
+  build:
+
+    runs-on: windows-2019
+
+    steps:
+    - name: Checkout repo
+      uses: actions/checkout@v3
+
+    - name: Add msbuild to PATH
+      uses: microsoft/setup-msbuild@v1
+
+    - name: MSBuild of plugin dll
+      working-directory: ./Demo Plugin/
+      run: msbuild NppManagedPluginDemo.sln /m /verbosity:detailed

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,7 @@
+version: 0.95.0.{build}
+image: Visual Studio 2019
+
+
+build_script:
+    - cd "%APPVEYOR_BUILD_FOLDER%"\Demo Plugin\
+    - msbuild NppManagedPluginDemo.sln /m /verbosity:detailed /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"


### PR DESCRIPTION
- see https://ci.appveyor.com/project/kbilsted/notepadpluspluspluginpack-net/builds/45189247 for appveyor build with VS2019. see https://ci.appveyor.com/project/kbilsted/notepadpluspluspluginpack-net/builds/45189213 for Net. Framework 4.0 issue with VS2022 
- github action for CI build (used VS2019 as with VS2022 at least Net. Framework 4.5.2 is needed)

- Since Revision: 37867f1e4235de3c19824f50ed315d2500602833
 C# 7.0 from VS2017 is required, see
https://stackoverflow.com/questions/6308078/c-sharp-variable-name-underscore-only

therefore appveyor build fails which still used VS2015

