### PR TITLE
 change GetFilePath param from int to IntPtr

### DIFF
--- a/Demo Plugin/NppManagedPluginDemo/Demo.cs
+++ b/Demo Plugin/NppManagedPluginDemo/Demo.cs
@@ -1,5 +1,6 @@
 ﻿// NPP plugin platform for .Net v0.91.57 by Kasper B. Graversen etc.
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Text;
 using System.Drawing;
@@ -40,6 +41,10 @@ namespace Kbg.NppPluginNET
             {
                 Kbg.Demo.Namespace.Main.doInsertHtmlCloseTag((char)notification.Character);
             }
+            else if (notification.Header.Code == (uint)NppMsg.NPPN_FILEBEFORECLOSE)
+            {
+                Kbg.Demo.Namespace.Main.addFileToFilesClosed(notification.Header.IdFrom);
+            }
         }
 
         internal static string PluginName { get { return Kbg.Demo.Namespace.Main.PluginName; }}
@@ -56,6 +61,7 @@ namespace Kbg.Demo.Namespace
         static string sectionName = "Insert Extension";
         static string keyName = "doCloseTag";
         static bool doCloseTag = false;
+        static List<string> filesClosedThisSession = new List<string>();
         static string sessionFilePath = @"C:\text.session";
         static frmGoToLine frmGoToLine = null;
         static internal int idFrmGotToLine = -1;
@@ -136,6 +142,7 @@ namespace Kbg.Demo.Namespace
             PluginBase.SetCommand(16, "---", null);
 
             PluginBase.SetCommand(17, "Print Scroll and Row Information", PrintScrollInformation);
+            PluginBase.SetCommand(18, "Show files closed this session", filesClosedDemo);
         }
 
         /// <summary>
@@ -351,6 +358,19 @@ The current scroll ratio is {Math.Round(scrollPercentage, 2)}%.
                     }
                 }
             }
+        }
+
+        static internal void addFileToFilesClosed(IntPtr bufClosedId)
+        {
+            var bufClosedName = notepad.GetFilePath(bufClosedId);
+            filesClosedThisSession.Add(bufClosedName);
+        }
+
+        static void filesClosedDemo()
+        {
+            var filesClosed = string.Join("\r\n", filesClosedThisSession);
+            MessageBox.Show($"Files closed this session:\r\n{filesClosed}",
+                "Files closed this session");
         }
 
         static void getFileNamesDemo()

--- a/Demo Plugin/NppManagedPluginDemo/Demo.cs
+++ b/Demo Plugin/NppManagedPluginDemo/Demo.cs
@@ -143,7 +143,7 @@ namespace Kbg.Demo.Namespace
 
             PluginBase.SetCommand(17, "Print Scroll and Row Information", PrintScrollInformation);
             PluginBase.SetCommand(18, "Show files closed this session", filesClosedDemo);
-            PluginBase.SetCommand(19, "Use NanInf class for -inf, inf, nan!!", PrintNanInf)
+            PluginBase.SetCommand(19, "Use NanInf class for -inf, inf, nan!!", PrintNanInf);
         }
 
         /// <summary>

--- a/Visual Studio Project Template C#/PluginInfrastructure/NotepadPPGateway.cs
+++ b/Visual Studio Project Template C#/PluginInfrastructure/NotepadPPGateway.cs
@@ -16,7 +16,7 @@ namespace Kbg.NppPluginNET.PluginInfrastructure
 		string GetNppPath();
 		string GetPluginConfigPath();
 		string GetCurrentFilePath();
-		unsafe string GetFilePath(int bufferId);
+		unsafe string GetFilePath(IntPtr bufferId);
 		void SetCurrentLanguage(LangType language);
 		bool OpenFile(string path);
 	}
@@ -108,7 +108,7 @@ namespace Kbg.NppPluginNET.PluginInfrastructure
 		/// <summary>
 		/// Gets the path of the current document.
 		/// </summary>
-		public unsafe string GetFilePath(int bufferId)
+		public unsafe string GetFilePath(IntPtr bufferId)
 		{
 			var path = new StringBuilder(2000);
 			Win32.SendMessage(PluginBase.nppData._nppHandle, (uint) NppMsg.NPPM_GETFULLPATHFROMBUFFERID, bufferId, path);


### PR DESCRIPTION
Previously the GetFilePath method of NotepadPPGateway was unusable in 64-bit Notepad++ because it accepted an int parameter, but the buffer id (the IdFrom parameter of the NPPN_FILEBEFORECLOSE notification) could be 64-bit.

Also added a new plugin command to Demo.cs illustrating how tracking the NPPN_FILEBEFORECLOSE notification allows the plugin to keep a list of all the filenames that were closed this session.